### PR TITLE
Update Docker image repository location for Arcane

### DIFF
--- a/apps/arcane/compose.yaml
+++ b/apps/arcane/compose.yaml
@@ -1,6 +1,6 @@
 services:
   arcane:
-    image: ghcr.io/ofkm/arcane:latest
+    image: ghcr.io/getarcaneapp/arcane:latest
     container_name: arcane
     restart: unless-stopped
     expose:


### PR DESCRIPTION
Updated Arcane's GHCR repository location as it has moved from _ofkm/arcane_ to _getarcaneapp/arcane_.