### PR TITLE
fix(syncribullet): copy dist instead of public/adapters in runtime Dockerfile

### DIFF
--- a/apps/syncribullet/compose.yaml
+++ b/apps/syncribullet/compose.yaml
@@ -26,10 +26,8 @@ services:
         RUN npm ci --ignore-scripts --only=production && npm cache clean --force
 
         # Copy built files from the builder stage
-        COPY --from=builder /build/public ./public
-        COPY --from=builder /build/adapters ./adapters
+        COPY --from=builder /build/dist ./dist
         COPY --from=builder /build/server ./server
-
         COPY --from=builder /build/node_modules ./node_modules
 
         ENV NODE_ENV=production


### PR DESCRIPTION
Problem:

The runtime stage of the inline Dockerfile in apps/syncribullet/compose.yaml copied /build/public and /build/adapters, but the project build outputs to /build/dist. This left the runtime image missing the built artifacts.

App would not run properly with previous compose.yaml, however after some troubleshooting help, this one works properly.

What this PR does:

- Replaces the incorrect COPY lines with:
            COPY --from=builder /build/dist ./dist
            COPY --from=builder /build/server ./server
            COPY --from=builder /build/node_modules ./node_modules

- Files changed:
        apps/syncribullet/compose.yaml