### PR TITLE
Webstremr: Use Docker image

### DIFF
--- a/apps/webstreamr/compose.yaml
+++ b/apps/webstreamr/compose.yaml
@@ -1,11 +1,8 @@
 services:
   webstreamr:
-    image: webstreamr
+    image: webstreamr/webstreamr
     container_name: webstreamr
     restart: unless-stopped
-    build:
-      context: https://github.com/webstreamr/webstreamr.git
-      dockerfile: Dockerfile
     expose:
       - 51546
     env_file:


### PR DESCRIPTION
The recommended way to run this is now the docker image.
See https://github.com/webstreamr/webstreamr?tab=readme-ov-file#self-hosting