### PR TITLE
fix(tweakio): Updated to use env vars instead of config file

### DIFF
--- a/apps/tweakio/.env
+++ b/apps/tweakio/.env
@@ -1,0 +1,6 @@
+# Optional but recommended for best results. See https://www.themoviedb.org/settings/api
+TMDB_API_KEY=
+
+# Run this container in the same network as gluetun, so it can access Torrentio.
+# If not blocked by Torrentio, you can remove this line.
+PROXY_URL=http://gluetun:8080

--- a/apps/tweakio/compose.yaml
+++ b/apps/tweakio/compose.yaml
@@ -3,17 +3,15 @@ services:
     image: varthe/tweakio:latest
     container_name: tweakio
     restart: unless-stopped
-    # Run this container in the same network as warp, so it can access Torrentio
-    # If not blocked by Torrentio, you can remove this line.
-    # Will need to be accesssed at http://warp:3185 if using warp.
-    network_mode: service:warp
+    ports:
+      - 3185:3185
     user: $PUID:$PGID
-    volumes:
-      - ./config.yaml:/app/config.yaml
+    env_file:
+      - .env
     profiles:
       - all
       - tweakio
     depends_on:
-      warp:
+      gluetun:
         condition: service_healthy
         restart: true

--- a/apps/tweakio/config.yaml
+++ b/apps/tweakio/config.yaml
@@ -1,7 +1,0 @@
-torrentio:
-  base_url: https://torrentio.strem.fun/
-  options: "providers=yts,eztv,rarbg,1337x,thepiratebay,kickasstorrents,torrentgalaxy,magnetdl,horriblesubs,nyaasi,tokyotosho,anidex|sort=qualitysize|qualityfilter=scr,cam"
-
-tmdb:
-  api_key: "" # If empty, defaults to 10 episodes for everything
-  cache_size: 1000


### PR DESCRIPTION
The yaml config was deprecated for a while, and has now been removed.
Warp also doesn't work with Torrentio anymore, so I replaced it with gluetun 

https://github.com/varthe/tweakio