### PR TITLE
usenet-streamer: add persistent storage

### DIFF
--- a/apps/usenet-streamer/compose.yaml
+++ b/apps/usenet-streamer/compose.yaml
@@ -17,7 +17,7 @@ services:
     environment:
       - CONFIG_DIR=/data/config
     volumes:
-      - ${DOCKER_DATA_DIR}/usenetstreamer:/data/config
+      - ${DOCKER_DATA_DIR}/usenet-streamer:/data/config
     profiles:
       - usenet-streamer
       - all


### PR DESCRIPTION
Usenet-Streamer: Currently a persistant configuration can only be done via the .env file currently, all changes in the webinterface are held at runtime and get lost on reboots/updates.