### PR TITLE
Rename postgres service to comet_postgres

### DIFF
--- a/apps/comet/compose.yaml
+++ b/apps/comet/compose.yaml
@@ -25,7 +25,7 @@ services:
       retries: 5
       start_period: 10s
     depends_on:
-      postgres:
+      comet_postgres:
         condition: service_healthy
     profiles:
       - comet


### PR DESCRIPTION
Fixing error in docker compose: service "comet" depends on undefined service "postgres": invalid compose project