### PR TITLE
fix(authelia): add authn_strategies for Beszel forward-auth compatibility

### DIFF
--- a/apps/authelia/config/configuration.yml
+++ b/apps/authelia/config/configuration.yml
@@ -105,6 +105,8 @@ server:
     authz:
       forward-auth:
         implementation: 'ForwardAuth'
+        authn_strategies:
+          - name: 'CookieSession'
         # authn_strategies: []
       # ext-authz:
         # implementation: 'ExtAuthz'


### PR DESCRIPTION
## Summary

Fixes recurring authentication prompts when using Authelia v4.39.15+ with Beszel by adding `CookieSession` authentication strategy to the forward-auth endpoint configuration.

## Problem

Since Authelia v4.39.15, users experience authentication issues with Beszel (repeated login prompts or authorization errors) when using forward-auth. This is due to missing `authn_strategies` configuration in the Authelia configuration.

## Solution

Added the following configuration to `apps/authelia/config/configuration.yml`:

```yaml
server:
  endpoints:
    authz:
      forward-auth:
        implementation: 'ForwardAuth'
        authn_strategies:
          - name: 'CookieSession'
```

## References

- [Beszel Documentation - Common Issues](https://beszel.dev/guide/common-issues#authelia-forward-auth-not-working)
- [GitHub Issue #1482](https://github.com/henrygd/beszel/issues/1482)