### PR TITLE
fix: plexio arm64 compatibility

### DIFF
--- a/apps/plexio/compose.yaml
+++ b/apps/plexio/compose.yaml
@@ -1,6 +1,6 @@
 services:
   plexio:
-    image: ghcr.io/vanchaxy/plexio
+    image: plexio
     container_name: plexio
     restart: unless-stopped
     build:


### PR DESCRIPTION
## Problem

The plexio service fails to start on ARM64 hosts (e.g., Oracle Cloud ARM VPS) with the following error:
```
! plexio The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

This is because `image: ghcr.io/vanchaxy/plexio` causes Docker Compose to attempt pulling the pre-built image from GHCR, which is only published for `linux/amd64`. Even though a `build:` block is defined, the registry image reference takes priority and triggers the platform mismatch.

## Fix

- Changed `image: ghcr.io/vanchaxy/plexio` to `image: plexio` so Docker Compose uses the local build instead of trying to pull the amd64-only registry image.