### PR TITLE
fix(webstreamr): add cache dir volume mapping

### DIFF
--- a/apps/webstreamr/.env
+++ b/apps/webstreamr/.env
@@ -24,6 +24,6 @@ TMDB_ACCESS_TOKEN=
 # ALL_PROXY=
 
 # Set a URL to a FlareSolverr/Byparr instance
-# e.g. http://byparr:8191/v1
+# e.g. http://flaresolverr:8191/v1 or http://byparr:8191/v1
 # FLARESOLVERR_ENDPOINT=
 

--- a/apps/webstreamr/compose.yaml
+++ b/apps/webstreamr/compose.yaml
@@ -14,6 +14,8 @@ services:
       - "traefik.http.routers.webstreamr.tls.certresolver=letsencrypt"
       - "traefik.http.routers.webstreamr.middlewares=authelia@docker"
       - "traefik.http.services.webstreamr.loadbalancer.server.port=51546"
+    volumes:
+      - ${DOCKER_DATA_DIR}/webstreamr/cache:/tmp
     healthcheck:
       test:
         [


### PR DESCRIPTION
From the [discussion here](https://github.com/webstreamr/webstreamr/issues/743#issue-4008104586), adding volume mapping for webstreamr's tmp directory so that it is persistent. Also adding example of flaresolverr endpoint url.