### PR TITLE
feat: Add FlareSolverr

### DIFF
--- a/apps/flaresolverr/compose.yaml
+++ b/apps/flaresolverr/compose.yaml
@@ -1,0 +1,24 @@
+services:
+  flaresolverr:
+    # DockerHub mirror flaresolverr/flaresolverr:latest
+    image: ghcr.io/flaresolverr/flaresolverr:latest
+    container_name: flaresolverr
+    environment:
+      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - LOG_FILE=${LOG_FILE:-none}
+      - LOG_HTML=${LOG_HTML:-false}
+      - CAPTCHA_SOLVER=${CAPTCHA_SOLVER:-none}
+      - TZ=${TZ}
+    expose:
+      - ${PORT:-8191}
+    volumes:
+      - ${DOCKER_DATA_DIR}/flaresolverr:/config
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8191/health | grep -q '\"status\": \"ok'"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    profiles:
+      - flaresolverr
+      - all

--- a/compose.yaml
+++ b/compose.yaml
@@ -31,6 +31,7 @@ include:
   - apps/easynews-plus/compose.yaml
   - apps/easynews-plus-plus/compose.yaml
   - apps/fivefilters-full-text-rss/compose.yaml
+  - apps/flaresolverr/compose.yaml
   - apps/freshrss/compose.yaml
   - apps/gluetun/compose.yaml
   - apps/homarr/compose.yaml


### PR DESCRIPTION
[FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) is under semi-active maintenance again. I've been using it as the endpoint for WebStreamr and it works perfectly. The image size is also far smaller than byparr's, and memory usage is on average 100-200mb lower in my experience.