### PR TITLE
Add XRDB app template with Authelia and Cloudflare DDNS wiring

### DIFF
--- a/.env
+++ b/.env
@@ -209,6 +209,10 @@ VAULTWARDEN_HOSTNAME=vaultwarden.${DOMAIN}
 WALLOS_HOSTNAME=wallos.${DOMAIN}
 WEBSTREAMR_HOSTNAME=webstreamr.${DOMAIN}
 WUD_HOSTNAME=wud.${DOMAIN}
+XRDB_HOSTNAME=xrdb.${DOMAIN}
+# Override if XRDB should use non-default Traefik entrypoints or cert resolver values.
+# XRDB_TRAEFIK_ENTRYPOINTS=websecure
+# XRDB_TRAEFIK_CERTRESOLVER=letsencrypt
 YAMTRACK_HOSTNAME=yamtrack.${DOMAIN}
 ZILEAN_HOSTNAME=zilean.${DOMAIN}
 ZIPLINE_HOSTNAME=zipline.${DOMAIN}

--- a/apps/authelia/compose.yaml
+++ b/apps/authelia/compose.yaml
@@ -50,6 +50,7 @@ services:
       TEMPLATE_ALTMOUNT_HOSTNAME: ${ALTMOUNT_HOSTNAME?}
       TEMPLATE_NZBDAV_HOSTNAME: ${NZBDAV_HOSTNAME?}
       TEMPLATE_NZBHYDRA2_HOSTNAME: ${NZBHYDRA2_HOSTNAME?}
+      TEMPLATE_XRDB_HOSTNAME: ${XRDB_HOSTNAME?}
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.authelia.rule=Host(`${AUTHELIA_HOSTNAME?}`)"

--- a/apps/authelia/config/configuration.yml
+++ b/apps/authelia/config/configuration.yml
@@ -790,6 +790,22 @@ access_control:
         - '^/openapi/.*$' 
       policy: 'bypass'
 
+    ## XRDB image and proxy endpoints bypass authentication for media clients
+    - domain: '{{ env "TEMPLATE_XRDB_HOSTNAME" }}'
+      resources:
+        - '^/poster(/.*)?$'
+        - '^/backdrop(/.*)?$'
+        - '^/logo(/.*)?$'
+        - '^/thumbnail(/.*)?$'
+        - '^/proxy(/.*)?$'
+        - '^/preview(/.*)?$'
+        - '^/api(/.*)?$'
+        - '^/_next(/.*)?$'
+        - '^/favicon\.ico$'
+        - '^/assets(/.*)?$'
+        - '^/fonts(/.*)?$'
+      policy: 'bypass'
+
     - domain: '*.{{ env "TEMPLATE_DOMAIN" }}'
       policy: 'two_factor'
 

--- a/apps/cloudflare-ddns/compose.yaml
+++ b/apps/cloudflare-ddns/compose.yaml
@@ -108,6 +108,7 @@ services:
         ${WALLOS_HOSTNAME},
         ${WEBSTREAMR_HOSTNAME},
         ${WUD_HOSTNAME},
+        ${XRDB_HOSTNAME},
         ${YAMTRACK_HOSTNAME},
         ${ZILEAN_HOSTNAME},
         ${ZIPLINE_HOSTNAME},

--- a/apps/xrdb/.env
+++ b/apps/xrdb/.env
@@ -1,0 +1,387 @@
+# XRDB, eXtended Ratings DataBase, environment template
+#
+# Keep only the values you want to set for this app.
+
+# Core runtime
+
+# NODE_ENV
+# Sets the runtime mode.
+# Use production for servers.
+# Use development only for local debugging.
+NODE_ENV=production
+
+# XRDB_LOG_LEVEL
+# Server console log threshold for XRDB runtime logs.
+# debug and info write to STDOUT.
+# warn and error write to STDERR.
+XRDB_LOG_LEVEL=info
+
+# XRDB_REQUEST_LOG_LEVEL
+# Optional override for routine image request logs.
+# Leave unset to keep request logs off by default.
+# Accepted values: off, debug, info, warn, error
+# XRDB_REQUEST_LOG_LEVEL=off
+
+# XRDB_PREVIEW_ORIGIN
+# Trusted preview origin used by /preview/[slug] when the app calls itself.
+# Set this explicitly in production when XRDB should call the public host.
+# XRDB_PREVIEW_ORIGIN=https://xrdb.example.com
+
+# PREVIEW_INTERNAL_ORIGIN
+# Legacy alias still accepted during migration.
+PREVIEW_INTERNAL_ORIGIN=http://127.0.0.1:3000
+
+# XRDB_TRUST_PROXY_HEADERS
+# Trust forwarded host and protocol headers from a reverse proxy.
+XRDB_TRUST_PROXY_HEADERS=true
+
+# Proxy networking
+
+# HTTP_PROXY
+# HTTPS_PROXY
+# Optional outbound proxy settings for XRDB.
+# Use these if your server routes traffic through something like gluetun.
+# HTTP_PROXY=http://127.0.0.1:8080
+# HTTPS_PROXY=http://127.0.0.1:8080
+
+# Brand links
+
+# These values control the visible support and community links in the app.
+# Leave them blank to use the built in defaults.
+
+# NEXT_PUBLIC_BRAND_GITHUB_URL
+# URL for the project GitHub repository link shown in the app.
+# NEXT_PUBLIC_BRAND_GITHUB_URL=https://github.com/IbbyLabs/XRDB
+
+# NEXT_PUBLIC_BRAND_GITHUB_LABEL
+# Label shown for the GitHub repository link.
+# NEXT_PUBLIC_BRAND_GITHUB_LABEL=XRDB Repo
+
+# NEXT_PUBLIC_BRAND_SUPPORT_URL
+# URL for the support link shown in the app.
+# NEXT_PUBLIC_BRAND_SUPPORT_URL=https://kofi.ibbylabs.dev
+
+# NEXT_PUBLIC_BRAND_UPTIME_URL
+# URL for the uptime status page linked from the app.
+# NEXT_PUBLIC_BRAND_UPTIME_URL=https://uptime.ibbylabs.dev
+
+# NEXT_PUBLIC_BRAND_DISCORD_AIO_URL
+# Invite or direct channel link for AIOMetadata support in the shared AIOStreams community.
+# NEXT_PUBLIC_BRAND_DISCORD_AIO_URL=https://discord.gg/DdXgUY7e8z
+
+# NEXT_PUBLIC_BRAND_DISCORD_AIO_LABEL
+# Label shown for the AIOMetadata support link.
+# NEXT_PUBLIC_BRAND_DISCORD_AIO_LABEL=AIOMetadata on AIOStreams
+
+# NEXT_PUBLIC_BRAND_DISCORD_OFFICIAL_URL
+# Invite for the direct project community.
+# NEXT_PUBLIC_BRAND_DISCORD_OFFICIAL_URL=https://discord.gg/wPY2pcqjmm
+
+# NEXT_PUBLIC_BRAND_DISCORD_OFFICIAL_LABEL
+# Label shown for the direct project community link.
+# NEXT_PUBLIC_BRAND_DISCORD_OFFICIAL_LABEL=Join the XRDB Community
+
+# NEXT_PUBLIC_BRAND_DISCORD_DM_URL
+# Direct contact link used as a fallback when invite links fail.
+# NEXT_PUBLIC_BRAND_DISCORD_DM_URL=https://discord.com/users/947862578682548255
+
+# NEXT_PUBLIC_BRAND_DISCORD_DM_HANDLE
+# Visible handle used beside the fallback direct contact link.
+# NEXT_PUBLIC_BRAND_DISCORD_DM_HANDLE=@ibbys89
+
+# Request access and CORS
+
+# XRDB_REQUEST_API_KEY
+# Single shared request key for render and proxy access.
+# Use this when you want to protect a private host with one key.
+# XRDB_REQUEST_API_KEY=
+
+# XRDB_REQUEST_API_KEYS
+# Comma separated list of valid request keys.
+# Use this when you need multiple valid keys instead of one shared key.
+# XRDB_REQUEST_API_KEYS=
+
+# XRDB_PROXY_ALLOWED_ORIGINS
+# CORS allowlist for proxy responses.
+# Use * for an open proxy host or a comma separated list for a stricter setup.
+# XRDB_PROXY_ALLOWED_ORIGINS=*
+
+# XRDB_CONFIG_ENCRYPTION_KEY
+# 64 hex character string (32 bytes) used to encrypt saved config profile params at rest.
+# If not set, a key is auto-generated on first boot and written to data/.config-key.
+# Set this explicitly in production and back it up. Losing the key makes existing profiles unreadable.
+# Generate with: openssl rand -hex 32
+# XRDB_CONFIG_ENCRYPTION_KEY=
+
+# XRDB_INACTIVE_CONFIG_PRUNE_DAYS
+# Number of days of inactivity before a saved config profile is automatically deleted on startup.
+# Inactivity is measured from the last time the profile was resolved by an image request.
+# Set to -1 (default) to disable pruning entirely.
+# Example: 7 deletes profiles not hit by any image request in the last 7 days.
+# XRDB_INACTIVE_CONFIG_PRUNE_DAYS=-1
+
+# WEBHOOK_URL
+# Optional release webhook target used by the release tooling.
+# Leave blank if you do not use release notifications.
+# WEBHOOK_URL=
+
+# Metadata providers
+
+# MDBLIST_API_KEY
+# Primary MDBList key used as a server side fallback for rating aggregation on hosted instances.
+# MDBLIST_API_KEY=
+
+# MDBLIST_API_KEYS
+# Optional comma separated pool of MDBList keys.
+# Useful for larger shared hosts that rotate between multiple keys.
+# MDBLIST_API_KEYS=
+
+# XRDB_README_PREVIEW_TMDB_KEY
+# Dedicated TMDB key used only for fixed README preview routes.
+# Keep this separate from your main key if you want isolated preview traffic.
+# XRDB_README_PREVIEW_TMDB_KEY=
+
+# XRDB_README_PREVIEW_MDBLIST_KEY
+# Dedicated MDBList key used only for fixed README preview routes.
+# XRDB_README_PREVIEW_MDBLIST_KEY=
+
+# XRDB_TMDB_API_BASE_URL
+# Override for the TMDB API base URL.
+# Leave this alone unless you are routing TMDB through a custom gateway.
+# XRDB_TMDB_API_BASE_URL=https://api.themoviedb.org/3
+
+# XRDB_ANILIST_GRAPHQL_URL
+# Override for the AniList GraphQL endpoint.
+# XRDB_ANILIST_GRAPHQL_URL=https://graphql.anilist.co
+
+# XRDB_ANIME_MAPPING_BASE_URL
+# Override for the anime mapping service base URL.
+# Used for anime id crosswalks and reverse lookup help.
+# XRDB_ANIME_MAPPING_BASE_URL=https://animemapping.stremio.dpdns.org
+
+# XRDB_KITSU_API_BASE_URL
+# Override for the Kitsu API base URL.
+# XRDB_KITSU_API_BASE_URL=https://kitsu.io/api/edge
+
+# XRDB_MAL_CLIENT_ID
+# MyAnimeList v2 client id used for direct MAL lookups.
+# If blank, XRDB falls back to Jikan where possible.
+# XRDB_MAL_CLIENT_ID=
+
+# XRDB_MAL_API_BASE_URL
+# Override for the official MyAnimeList API base URL.
+# XRDB_MAL_API_BASE_URL=https://api.myanimelist.net/v2
+
+# XRDB_JIKAN_API_BASE_URL
+# Override for the Jikan fallback API base URL.
+# XRDB_JIKAN_API_BASE_URL=https://api.jikan.moe/v4
+
+# XRDB_TRAKT_CLIENT_ID
+# Trakt client id used for direct Trakt rating lookups.
+# XRDB_TRAKT_CLIENT_ID=
+
+# XRDB_TRAKT_API_BASE_URL
+# Override for the Trakt API base URL.
+# XRDB_TRAKT_API_BASE_URL=https://api.trakt.tv
+
+# OMDB_KEY
+# OMDb API key used for poster lookups when posterArtworkSource=omdb.
+# XRDB_OMDB_API_KEY and OMDB_API_KEY are also supported, but OMDB_KEY is the simplest local name.
+# OMDB_KEY=
+
+# XRDB_OMDB_API_BASE_URL
+# Override for the OMDb API base URL.
+# XRDB_OMDB_API_BASE_URL=https://www.omdbapi.com
+
+# XRDB_FANART_API_KEY
+# Server side Fanart API key used as fallback when the user does not supply fanartKey.
+# FANART_API_KEY is also accepted.
+# XRDB_FANART_API_KEY=
+
+# XRDB_FANART_CLIENT_KEY
+# Server side Fanart client key.
+# FANART_CLIENT_KEY is also accepted.
+# XRDB_FANART_CLIENT_KEY=
+
+# SIMKL_CLIENT_ID
+# SIMKL client id used for direct SIMKL rating lookups.
+# SIMKL_CLIENT_ID=
+
+# XRDB_SIMKL_APP_NAME
+# App name sent to SIMKL in required request parameters.
+# Set this to xrdb when you want the outgoing client name to match the new brand.
+XRDB_SIMKL_APP_NAME=xrdb
+
+# XRDB_SIMKL_APP_VERSION
+# App version sent to SIMKL in required request parameters.
+XRDB_SIMKL_APP_VERSION=1.0
+
+# Cache windows
+
+# These values control how long source data stays cached before XRDB asks again.
+# Longer windows reduce source traffic.
+# Shorter windows pick up changes faster.
+
+# XRDB_TMDB_CACHE_TTL_MS
+# TMDB metadata cache duration.
+# XRDB_TMDB_CACHE_TTL_MS=259200000
+
+# XRDB_MDBLIST_CACHE_TTL_MS
+# MDBList ratings cache duration.
+# XRDB_MDBLIST_CACHE_TTL_MS=259200000
+
+# XRDB_KITSU_CACHE_TTL_MS
+# Kitsu metadata cache duration.
+# XRDB_KITSU_CACHE_TTL_MS=259200000
+
+# XRDB_OMDB_CACHE_TTL_MS
+# OMDb poster lookup cache duration.
+# XRDB_OMDB_CACHE_TTL_MS=259200000
+
+# XRDB_SIMKL_CACHE_TTL_MS
+# SIMKL metadata cache duration.
+# XRDB_SIMKL_CACHE_TTL_MS=259200000
+
+# XRDB_SIMKL_ID_CACHE_TTL_MS
+# SIMKL id resolution cache duration.
+# XRDB_SIMKL_ID_CACHE_TTL_MS=15552000000
+
+# XRDB_SIMKL_ID_EMPTY_CACHE_TTL_MS
+# Cache duration for empty SIMKL id results.
+# XRDB_SIMKL_ID_EMPTY_CACHE_TTL_MS=86400000
+
+# XRDB_TORRENTIO_CACHE_TTL_MS
+# Torrentio badge cache duration.
+# XRDB_TORRENTIO_CACHE_TTL_MS=21600000
+
+# XRDB_PROVIDER_ICON_CACHE_TTL_MS
+# Rating provider icon cache duration.
+# XRDB_PROVIDER_ICON_CACHE_TTL_MS=604800000
+
+# XRDB_IMDB_DATASET_CACHE_TTL_MS
+# Local IMDb dataset cache duration.
+# XRDB_IMDB_DATASET_CACHE_TTL_MS=604800000
+
+# XRDB_MDBLIST_OLD_MOVIE_CACHE_TTL_MS
+# Extended MDBList cache duration for older titles.
+# XRDB_MDBLIST_OLD_MOVIE_CACHE_TTL_MS=604800000
+
+# XRDB_MDBLIST_OLD_MOVIE_AGE_DAYS
+# Age threshold that decides when a title counts as old enough for the longer MDBList cache.
+# XRDB_MDBLIST_OLD_MOVIE_AGE_DAYS=365
+
+# XRDB_MDBLIST_RATE_LIMIT_COOLDOWN_MS
+# Cooldown window after MDBList rate limiting.
+# XRDB_MDBLIST_RATE_LIMIT_COOLDOWN_MS=86400000
+
+# Stream badges
+
+# XRDB_TORRENTIO_BASE_URL
+# Base URL for the Torrentio instance used by stream badge lookups.
+# XRDB_TORRENTIO_BASE_URL=https://torrentio.strem.fun
+
+# XRDB_TORRENTIO_CONCURRENCY
+# Maximum number of concurrent Torrentio badge lookups.
+# Higher values can speed things up but also raise rate limit risk.
+# XRDB_TORRENTIO_CONCURRENCY=2
+
+# XRDB_TORRENTIO_RATE_LIMIT_COOLDOWN_MS
+# Cooldown window after Torrentio rate limits the host.
+# XRDB_TORRENTIO_RATE_LIMIT_COOLDOWN_MS=900000
+
+# Local IMDb datasets
+
+# XRDB_IMDB_DATASET_AUTO_DOWNLOAD
+# Automatically download IMDb datasets when they are missing or stale.
+# XRDB_IMDB_DATASET_AUTO_DOWNLOAD=true
+
+# XRDB_IMDB_DATASET_AUTO_IMPORT
+# Automatically import downloaded IMDb datasets into the local SQLite store.
+# XRDB_IMDB_DATASET_AUTO_IMPORT=true
+
+# XRDB_IMDB_DATASET_REFRESH_MS
+# How often XRDB should refresh the IMDb datasets.
+# XRDB_IMDB_DATASET_REFRESH_MS=259200000
+
+# XRDB_IMDB_DATASET_CHECK_INTERVAL_MS
+# How often XRDB checks whether a dataset refresh is due.
+# XRDB_IMDB_DATASET_CHECK_INTERVAL_MS=900000
+
+# XRDB_IMDB_DATASET_BASE_URL
+# Base URL used for IMDb dataset downloads.
+# XRDB_IMDB_DATASET_BASE_URL=https://datasets.imdbws.com
+
+# XRDB_IMDB_RATINGS_DATASET_PATH
+# Local file path for title.ratings.tsv.gz.
+# XRDB_IMDB_RATINGS_DATASET_PATH=./data/imdb/title.ratings.tsv.gz
+
+# XRDB_IMDB_EPISODES_DATASET_PATH
+# Local file path for title.episode.tsv.gz.
+# XRDB_IMDB_EPISODES_DATASET_PATH=./data/imdb/title.episode.tsv.gz
+
+# XRDB_IMDB_RATINGS_DATASET_URL
+# Full download URL for the ratings dataset if you want to override the default.
+# XRDB_IMDB_RATINGS_DATASET_URL=https://datasets.imdbws.com/title.ratings.tsv.gz
+
+# XRDB_IMDB_EPISODES_DATASET_URL
+# Full download URL for the episode dataset if you want to override the default.
+# XRDB_IMDB_EPISODES_DATASET_URL=https://datasets.imdbws.com/title.episode.tsv.gz
+
+# XRDB_IMDB_DATASET_IMPORT_BATCH
+# SQLite import batch size used during dataset loads.
+# XRDB_IMDB_DATASET_IMPORT_BATCH=5000
+
+# XRDB_IMDB_DATASET_IMPORT_PROGRESS
+# Optional saved progress marker for resumable imports.
+# XRDB_IMDB_DATASET_IMPORT_PROGRESS=0
+
+# XRDB_IMDB_DATASET_LOG
+# Enable verbose IMDb dataset sync logging.
+# XRDB_IMDB_DATASET_LOG=false
+
+# Sharp tuning
+
+# These values control image rendering concurrency and Sharp cache pressure.
+# Raise them carefully on stronger hosts.
+
+# XRDB_SHARP_CONCURRENCY
+# Maximum Sharp worker threads used for rendering.
+# XRDB_SHARP_CONCURRENCY=4
+
+# XRDB_SHARP_CACHE_MEMORY_MB
+# Sharp cache memory limit in megabytes.
+# XRDB_SHARP_CACHE_MEMORY_MB=512
+
+# XRDB_SHARP_CACHE_ITEMS
+# Maximum number of cached Sharp items.
+# XRDB_SHARP_CACHE_ITEMS=2000
+
+# XRDB_SHARP_CACHE_FILES
+# Maximum number of cached Sharp file handles.
+# XRDB_SHARP_CACHE_FILES=20000
+
+# Suggested small host
+# XRDB_SHARP_CONCURRENCY=2
+# XRDB_SHARP_CACHE_MEMORY_MB=128
+# XRDB_SHARP_CACHE_ITEMS=512
+# XRDB_SHARP_CACHE_FILES=2000
+
+# Suggested medium host
+# XRDB_SHARP_CONCURRENCY=4
+# XRDB_SHARP_CACHE_MEMORY_MB=512
+# XRDB_SHARP_CACHE_ITEMS=2000
+# XRDB_SHARP_CACHE_FILES=20000
+
+# Suggested public host
+# XRDB_SHARP_CONCURRENCY=4
+# XRDB_SHARP_CACHE_MEMORY_MB=512
+# XRDB_SHARP_CACHE_ITEMS=2000
+# XRDB_SHARP_CACHE_FILES=20000
+# XRDB_TORRENTIO_CACHE_TTL_MS=43200000
+# XRDB_TORRENTIO_CONCURRENCY=3
+
+# Suggested large host
+# XRDB_SHARP_CONCURRENCY=8
+# XRDB_SHARP_CACHE_MEMORY_MB=1024
+# XRDB_SHARP_CACHE_ITEMS=4000
+# XRDB_SHARP_CACHE_FILES=50000

--- a/apps/xrdb/compose.yaml
+++ b/apps/xrdb/compose.yaml
@@ -15,8 +15,8 @@ services:
       - "traefik.http.routers.xrdb.rule=Host(`${XRDB_HOSTNAME?}`)"
       - "traefik.http.routers.xrdb.entrypoints=${XRDB_TRAEFIK_ENTRYPOINTS:-websecure}"
       - "traefik.http.routers.xrdb.tls.certresolver=${XRDB_TRAEFIK_CERTRESOLVER:-letsencrypt}"
+      - "traefik.http.routers.xrdb.middlewares=authelia@docker"
       - "traefik.http.services.xrdb.loadbalancer.server.port=3000"
-      # - "traefik.http.routers.xrdb.middlewares=authelia@docker"
     volumes:
       - ${DOCKER_DATA_DIR}/xrdb:/app/data
     profiles:

--- a/apps/xrdb/compose.yaml
+++ b/apps/xrdb/compose.yaml
@@ -1,0 +1,24 @@
+services:
+  xrdb:
+    image: ghcr.io/ibbylabs/xrdb:latest
+    container_name: xrdb
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      PORT: 3000
+      HOSTNAME: 0.0.0.0
+    expose:
+      - 3000
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.xrdb.rule=Host(`${XRDB_HOSTNAME?}`)"
+      - "traefik.http.routers.xrdb.entrypoints=${XRDB_TRAEFIK_ENTRYPOINTS:-websecure}"
+      - "traefik.http.routers.xrdb.tls.certresolver=${XRDB_TRAEFIK_CERTRESOLVER:-letsencrypt}"
+      - "traefik.http.services.xrdb.loadbalancer.server.port=3000"
+      # - "traefik.http.routers.xrdb.middlewares=authelia@docker"
+    volumes:
+      - ${DOCKER_DATA_DIR}/xrdb:/app/data
+    profiles:
+      - xrdb
+      - all

--- a/compose.yaml
+++ b/compose.yaml
@@ -105,6 +105,7 @@ include:
   - apps/watchtower/compose.yaml
   - apps/webstreamr/compose.yaml
   - apps/wud/compose.yaml
+  - apps/xrdb/compose.yaml
   - apps/yamtrack/compose.yaml
   - apps/zilean/compose.yaml
   - apps/zipline/compose.yaml


### PR DESCRIPTION
## Summary

Add XRDB to the docker-compose template as a first-class app module.

## Included

- add `apps/xrdb/compose.yaml`
- add `apps/xrdb/.env` with the XRDB environment surface
- add `XRDB_HOSTNAME` and XRDB Traefik override vars to the root `.env`
- include XRDB in the root `compose.yaml`
- wire XRDB into Authelia with `TEMPLATE_XRDB_HOSTNAME`
- add XRDB bypass rules for image, proxy, preview, API, and static asset routes in Authelia config
- enable `authelia@docker` on the XRDB router
- add XRDB to the Cloudflare DDNS domain list

## Why

This makes XRDB work out of the box in the same style as the other app modules in the template, including reverse proxy routing, optional DNS automation, and Authelia protection without breaking media-client-facing endpoints.

## Notes

- UI and non-bypassed routes are protected by Authelia
- poster, backdrop, logo, thumbnail, proxy, preview, API, and static asset routes bypass Authelia so clients can still fetch images


Hey boss @Viren070 i know you’re busy but I’d appreciate it if you would be willing to check this out and approve it for people. Thank you 🫡 