### PR TITLE
fix(xrdb): precreate data directory and manually pin sqlite to mount vol

### DIFF
--- a/apps/xrdb/compose.yaml
+++ b/apps/xrdb/compose.yaml
@@ -7,6 +7,7 @@ services:
       - .env
     environment:
       PORT: 3000
+      XRDB_DB_PATH: /app/data/xrdb.db
     expose:
       - 3000
     labels:


### PR DESCRIPTION
Add data/xrdb/.gitkeep to precreate host side bind mount directory when users clone the template. This prevents Docker from creating the directory as root on first `compose up`, which causes a permission failure when the container runs as non root.

Fixes the below problem:
```
SqliteError: unable to open database file
at <unknown> (.next/server/chunks/147.js:117:1974)
at v (.next/server/chunks/147.js:117:2057)
at y (.next/server/chunks/147.js:117:2202)
at z (.next/server/chunks/147.js:117:2549)
at E (.next/server/chunks/147.js:123:173)
at gs (.next/server/chunks/790.js:364:9084)
at gt (.next/server/chunks/790.js:364:11413) {
code: 'SQLITE_CANTOPEN'
}
SqliteError: unable to open database file
at <unknown> (.next/server/chunks/147.js:117:1974)
at v (.next/server/chunks/147.js:117:2057)
at y (.next/server/chunks/147.js:117:2202)
at z (.next/server/chunks/147.js:117:2549)
at E (.next/server/chunks/147.js:123:173)
at gs (.next/server/chunks/790.js:364:9084)
at gt (.next/server/chunks/790.js:364:11413) {
code: 'SQLITE_CANTOPEN'
}
```

Brought to my attention by @Mrkaon off discord. (If you see this thank you boss.)

A long term fix (userid support) in XRDB's entrypoint will be committed shortly.