### PR TITLE
fix(arcane): mount DOCKER_DIR to allow compose project resolution in v2.0

### DIFF
--- a/apps/arcane/compose.yaml
+++ b/apps/arcane/compose.yaml
@@ -22,6 +22,8 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${DOCKER_DATA_DIR}/arcane:/app/data
+      - ${DOCKER_DIR}:${DOCKER_DIR}
+
     profiles:
       - arcane
       - all 


### PR DESCRIPTION
 ### 📝 Title

fix(arcane): mount DOCKER_DIR to allow compose project resolution in v2.0+

 ### 💬 Description

 ### Problem
 Starting with version `v2.0.0`, Arcane resolves container updates by reading the Docker Compose metadata labels on the host containers specifically the project's working directory `com.docker.compose.project.working_dir` and configuration files `com.docker.compose.project.config_files`).

Because Arcane runs inside a container, it lacks access to the host's directory paths (e.g., `/home/ubuntu/homelab`), resulting in the following error when trying to update or redeploy containers (like `nzbdavex` or `usenetstreamer`):`resolve compose project: project not found: <project_name>`

### Solution
Mount the host's compose project directory to the exact same path inside the Arcane container using the template's standard `DOCKER_DIR:{DOCKER_DIR}` volume mapping. This allows Arcane to successfully find, read, and resolve the compose files during the container update/redeploy process.

### Changes
* Updated `apps/arcane/compose.yaml` to include ` -DOCKER_DIR:{DOCKER_DIR}` in the `volumes` section.