### PR TITLE
fix(uptime-kuma): update deprecated latest tag to v2

### DIFF
--- a/apps/uptime-kuma/compose.yaml
+++ b/apps/uptime-kuma/compose.yaml
@@ -1,6 +1,6 @@
 services:
   uptime-kuma:
-    image: louislam/uptime-kuma:latest
+    image: louislam/uptime-kuma:2-slim
     container_name: kuma
     restart: unless-stopped
     # environment:


### PR DESCRIPTION
Uptime kuma "latest" docker tag was deprecated and is pointing o a old version 1.23.17.

Docs: https://github.com/louislam/uptime-kuma/wiki/Docker-Tags

> Warning
> 
> latest tag is deprecated, which is always pointing to v1. Please consider using Recommended Tags.
> 
> Note
> 
> If you want to upgrade from v1 to v2, be sure to read the [migration guide](https://github.com/louislam/uptime-kuma/wiki/Migration-From-v1-To-v2) first.
> 

Image updated to tag 2-slim. 
[slim vs full](https://github.com/louislam/uptime-kuma/wiki/Docker-Tags#slim-vs-full)