### PR TITLE
feat(maille): add postgres backup to B2 with Kuma push alerting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ desktop.ini
 .idea/
 *.swp
 *.swo
+
+# Env files (already tracked ones stay tracked; this only affects new ones)
+.env*

--- a/apps/aiometadata/compose.yaml
+++ b/apps/aiometadata/compose.yaml
@@ -4,7 +4,7 @@ services:
     container_name: aiometadata
     restart: unless-stopped
     expose:
-      - ${PORT:-3232}
+      - ${PORT:-1337}
     logging:
       driver: "json-file"
       options:
@@ -19,8 +19,7 @@ services:
       - "traefik.http.routers.aiometadata.rule=Host(`${AIOMETADATA_HOSTNAME?}`)"
       - "traefik.http.routers.aiometadata.entrypoints=websecure"
       - "traefik.http.routers.aiometadata.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.aiometadata.middlewares=authelia@docker"
-      - "traefik.http.services.aiometadata.loadbalancer.server.port=${PORT:-3232}"
+      - "traefik.http.services.aiometadata.loadbalancer.server.port=${PORT:-1337}"
     volumes:
       - ${DOCKER_DATA_DIR}/aiometadata/data:/app/addon/data
     depends_on:

--- a/apps/aiostreams/compose.yaml
+++ b/apps/aiostreams/compose.yaml
@@ -13,6 +13,7 @@ services:
       - "traefik.http.routers.aiostreams.entrypoints=websecure"
       - "traefik.http.routers.aiostreams.tls.certresolver=letsencrypt"
       - "traefik.http.routers.aiostreams.middlewares=authelia@docker"
+      - "com.centurylinklabs.watchtower.monitor-only=true"
     volumes:
       - ${DOCKER_DATA_DIR}/aiostreams:/app/data
     profiles:

--- a/apps/authelia/config/configuration.yml
+++ b/apps/authelia/config/configuration.yml
@@ -21,7 +21,7 @@
 # certificates_directory: '/config/certificates/'
 
 ## The theme to display: light, dark, grey, auto.
-theme: 'dark'
+theme: 'auto'
 
 ## Set the default 2FA method for new users and for when a user has a preferred method configured that has been
 ## disabled. This setting must be a method that is enabled.

--- a/apps/authelia/config/users.yml
+++ b/apps/authelia/config/users.yml
@@ -8,15 +8,15 @@
 
 users:
   ## change this to the username you want to use
-  user1:  
+  simon:  
     disabled: false
     ## change this to the display name you want to use
-    displayname: "User"  
+    displayname: "Simon"  
     ## Generate the argon 2 password hash using the following command
     ## sudo docker run --rm authelia/authelia:latest authelia crypto hash generate argon2 --password 'yourpassword'
     ## (currently the password is 'password')
-    password: "$argon2id$v=19$m=65536,t=3,p=4$9WCjag9NY9e/8OYGnPV1rg$OtXfECdXxgY+nI0ELWyRlSGKYV0a5QeW+r6mL1nXmoo"  
-    email: authelia@authelia.com
+    password: "$argon2id$v=19$m=65536,t=3,p=4$sf/Xi2aRFTBU8ddVAopJ6A$YOSV34RTQvKVGbziwDw6CACtOSfqVxTzqmyFVXnqXvY"  
+    email: hello@simoncaignart.com
     groups:
       - admins
       - dev

--- a/apps/cloudflare-ddns/compose.yaml
+++ b/apps/cloudflare-ddns/compose.yaml
@@ -12,7 +12,6 @@ services:
       CLOUDFLARE_API_TOKEN: "${CLOUDFLARE_API_TOKEN}"
       PROXIED: false
       DOMAINS: >
-        ${ACTUAL_BUDGET_HOSTNAME},
         ${ADDON_MANAGER_HOSTNAME},
         ${ADGUARD_HOSTNAME},
         ${AIOLISTS_HOSTNAME},
@@ -57,6 +56,7 @@ services:
         ${JELLYFIN_HOSTNAME},
         ${KARAKEEP_HOSTNAME},
         ${LIBRESPEED_HOSTNAME},
+        ${MAILLE_HOSTNAME},
         ${MEALIE_HOSTNAME},
         ${MEDIAFLOW_PROXY_HOSTNAME},
         ${MEDIAFUSION_HOSTNAME},
@@ -91,10 +91,6 @@ services:
         ${STREMIO_AI_COMPANION_HOSTNAME},
         ${STREMIO_AI_SEARCH_HOSTNAME},
         ${STREMIO_CATALOG_PROVIDERS_HOSTNAME},
-        ${STREMIO_JACKETT_HOSTNAME},
-        ${STREMIO_LETTERBOXD_HOSTNAME},
-        ${STREMIO_SERVER_HOSTNAME},
-        ${STREMIO_STREAMING_CATALOGS_HOSTNAME},
         ${STREMIO_TRAKT_ADDON_HOSTNAME},
         ${STREMTHRU_HOSTNAME},
         ${SYNCIO_HOSTNAME},
@@ -103,8 +99,6 @@ services:
         ${TAUTULLI_HOSTNAME},
         ${THE_LOUNGE_HOSTNAME},
         ${TMDB_ADDON_HOSTNAME},
-        ${TMDB_COLLECTIONS_HOSTNAME},
-        ${TORBOX_MANAGER_HOSTNAME},
         ${TRAEFIK_HOSTNAME},
         ${TULIPROX_HOSTNAME},
         ${UPTIME_KUMA_HOSTNAME},
@@ -116,9 +110,9 @@ services:
         ${WUD_HOSTNAME},
         ${XRDB_HOSTNAME},
         ${YAMTRACK_HOSTNAME},
+        ${ZAPCLONE_HOSTNAME},
         ${ZILEAN_HOSTNAME},
-        ${ZIPLINE_HOSTNAME},
-        ${ZURG_HOSTNAME}
+        ${ZIPLINE_HOSTNAME}
     profiles:
       - cloudflare-ddns
       - all

--- a/apps/honey/config.json
+++ b/apps/honey/config.json
@@ -1,16 +1,16 @@
 {
 	"ui": {
-		"name": "Dashboard",
-		"desc": "Nice and sweet place for all your self-hosted services.",
-		"icon": "img/icon.png",
-		"wallpaper": "img/background.jpg",
-		"wallpaper_dark": "img/background-dark.jpg",
+		"name": "My VPS",
+		"desc": "",
+		"icon": "",
+		"wallpaper": "",
+		"wallpaper_dark": "",
 		"dark_mode": "Auto",
 		"open_new_tab": true,
 		"ping_dots": false,
 		"blur": true,
 		"animations": true,
-		"trusted_domains": ["yourdomain.com"]
+		"trusted_domains": ["simoncaignart.com"]
 	},
 	"services": [
 		{
@@ -27,14 +27,14 @@
     },
 		{
 			"name": "dash.",
-			"desc": "A modern Server dashboard.",
-			"href": "https://dash.yourdomain.com",
+			"desc": "VPS Monitoring.",
+			"href": "https://dash.simoncaignart.com",
 			"icon": "https://getdashdot.com/img/logo512.png"
 		},
 		{
 			"name": "Dozzle",
-			"desc": "Docker logs in the browser.",
-			"href": "https://dozzle.yourdomain.com",
+			"desc": "Docker logs.",
+			"href": "https://dozzle.simoncaignart.com",
 			"icon": "https://raw.githubusercontent.com/amir20/dozzle/19bb8659135e4232523d45ff8e948a0907b2701c/docs/public/logo.svg"
 		},
 		{
@@ -46,177 +46,44 @@
 		{
 			"name": "Uptime Kuma",
 			"desc": "Self-hosted uptime monitor.",
-			"href": "https://kuma.yourdomain.com",
+			"href": "https://status.simoncaignart.com/dashboard",
 			"icon": "https://raw.githubusercontent.com/louislam/uptime-kuma/refs/heads/master/public/favicon.ico"
 		},
 		{
 			"name": "Status Page",
-			"desc": "Status page for all services.",
-			"href": "https://status.yourdomain.com",
+			"desc": "Status page for all the services.",
+			"href": "https://status.simoncaignart.com",
 			"icon": "https://raw.githubusercontent.com/louislam/uptime-kuma/refs/heads/master/public/favicon.ico"
 		},
 		{
-			"name": "Jellyfin",
-			"desc": "Media server",
-			"href": "https://jellyfin.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/jellyfin/jellyfin-ux/refs/heads/master/branding/tizen/icon.png"
-		},
-		{
-			"name": "Seerr",
-			"desc": "Jellyfin Media manager",
-			"href": "https://seerr.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/fallenbagel/jellyseerr/refs/heads/develop/public/android-chrome-512x512.png"
-		},
-		{
-			"name": "Plex",
-			"desc": "Media server",
-			"href": "https://plex.yourdomain.com",
-			"icon": "https://global.synologydownload.com/download/Package/img/PlexMediaServer/1.40.4.8840-72008840/thumb_256.png"
-		},
-		{
-			"name": "Seanime",
-			"desc": "Anime streaming service.",
-			"href": "https://seanime.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/5rahim/seanime/refs/heads/main/seanime-web/public/logo.png"
-		},
-		{
 			"name": "AIOStreams",
-			"desc": "All-In-One streaming add-on for Stremio.",
-			"href": "https://aiostreams.yourdomain.com",
+			"desc": "All-in-one streaming service.",
+			"href": "https://aiostreams.simoncaignart.com",
 			"icon": "https://raw.githubusercontent.com/Viren070/AIOStreams/refs/heads/main/packages/frontend/public/assets/logo.png"
 		},
 		{
-			"name": "AIOStremio",
-			"desc": "All-in-one streaming service.",
-			"href": "https://aiostremio.yourdomain.com",
-			"icon": "https://lh3.googleusercontent.com/d/1uudcj58lk4NXt9Qfk-1PC9vAH0LuPY0D"
-		},
-		{
-			"name": "Comet",
-			"desc": "Torrent/Debrid indexer for Stremio.",
-			"href": "https://comet.yourdomain.com",
-			"icon": "https://i.imgur.com/jmVoVMu.jpeg"
-		},
-		{
-			"name": "MediaFusion",
-			"desc": "Torrent/Debrid indexer for Stremio/Kodi.",
-			"href": "https://mediafusion.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/mhdzumair/MediaFusion/main/resources/images/mediafusion_logo.png"
-		},
-		{
-			"name": "Stremio-Jackett",
-			"desc": "Stremio add-on for Jackett.",
-			"href": "https://stremio-jackett.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/Jackett/Jackett/refs/heads/master/src/Jackett.Common/Content/jacket_medium.png"
-		},
-		{
-			"name": "Jackettio",
-			"desc": "Stremio add-on for Jackett.",
-			"href": "https://jackettio.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/Jackett/Jackett/refs/heads/master/src/Jackett.Common/Content/jacket_medium.png"
-		},
-		{
-			"name": "Easynews+",
-			"desc": "Stremio add-on for usenet content.",
-			"href": "https://easynews-plus.yourdomain.com",
-			"icon": "https://pbs.twimg.com/profile_images/479627852757733376/8v9zH7Yo_400x400.jpeg"
-		},
-		{
 			"name": "TMDB Addon",
-			"desc": "Stremio add-on for TMDB metadata.",
-			"href": "https://tmdb-addon.yourdomain.com",
+			"desc": "Stremio add-on for TMDB.",
+			"href": "https://tmdb.simoncaignart.com",
 			"icon": "https://raw.githubusercontent.com/mrcanelas/tmdb-addon/refs/heads/main/public/logo.png"
 		},
 		{
 			"name": "Stremio Catalog Providers",
 			"desc": "Stremio add-on for catalog providers.",
-			"href": "https://catalog-providers.yourdomain.com",
+			"href": "https://catalog-providers.simoncaignart.com",
 			"icon": "https://raw.githubusercontent.com/redd-ravenn/stremio-catalog-providers/refs/heads/main/public/assets/logo.png"
 		},
 		{
 			"name": "Stremio Trakt Addon",
 			"desc": "Stremio add-on for Trakt.",
-			"href": "https://trakt-addon.yourdomain.com",
+			"href": "https://trakt-addon.simoncaignart.com",
 			"icon": "https://raw.githubusercontent.com/redd-ravenn/stremio-catalog-providers/refs/heads/main/public/assets/logoTrakt.png"
 		},
 		{
-			"name": "MediaFlow",
-			"desc": "Proxy server for media streams.",
-			"href": "https://mediaflow-proxy.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/mhdzumair/mediaflow-proxy/refs/heads/main/mediaflow_proxy/static/logo.png"
-		},
-		{
-			"name": "StremThru",
-			"desc": "Companion suite for Stremio.",
-			"href": "https://stremthru.yourdomain.com",
-			"icon": "https://emojiapi.dev/api/v1/sparkles/256.png"
-		},
-		{
 			"name": "Stremio Addon Manager",
-			"desc": "Add-on manager for Stremio.",
-			"href": "https://addon-manager.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/Viren070/stremio-addon-manager/refs/heads/main/public/logo.png"
-		},
-		{
-			"name": "Cinebye",
-			"desc": "Add-on manager for Stremio with backup/restore and Cinemeta controls.",
-			"href": "https://cinebye.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/0xConstant1/stremio-addon-manager/refs/heads/main/public/logo.png"
-		},
-		{
-			"name": "Stremio Account Bootstrapper",
-			"desc": "Stremio account bootstrapper.",
-			"href": "https://stremio-account-bootstrapper.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/DryKillLogic/stremio-account-bootstrapper/refs/heads/main/public/favicon.ico"
-		},
-		{
-			"name": "Stremio Server",
-			"desc": "Stremio streaming server.",
-			"href": "https://stremio-server.yourdomain.com",
-			"icon": "https://www.stremio.com/website/stremio-purple-small.png"
-		},
-		{
-			"name": "Prowlarr",
-			"desc": "Indexer manager.",
-			"href": "https://prowlarr.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/Prowlarr/Prowlarr/refs/heads/develop/Logo/512.png"
-		},
-		{
-			"name": "Jackett",
-			"desc": "Torrent indexer.",
-			"href": "https://jackett.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/Jackett/Jackett/refs/heads/master/src/Jackett.Common/Content/jacket_medium.png"
-		},
-		{
-			"name": "NZBHydra2",
-			"desc": "Usenet indexer.",
-			"href": "https://nzbhydra.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/theotherp/nzbhydra2/refs/heads/master/core/ui-src/img/logo.png"
-		},
-		{
-			"name": "SearXNG",
-			"desc": "Privacy-respecting search engine.",
-			"href": "https://searxng.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/searxng/searxng/refs/heads/master/searx/static/themes/simple/img/favicon.png"
-		},
-		{
-			"name": "Plausible",
-			"desc": "Privacy-friendly web analytics.",
-			"href": "https://plausible.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/plausible/docs/master/static/img/plausible-analytics-icon-top.png"
-		},
-		{
-      "name": "Portainer",
-      "desc": "Manage Docker, Swarm, Kubernetes & ACI.",
-      "href": "https://portainer.yourdomain.com",
-      "icon": "https://avatars.githubusercontent.com/u/22225832?s=280&v=4"
-    },
-		{
-			"name": "Vaultwarden",
-			"desc": "Password Manager",
-			"href": "https://vaultwarden.yourdomain.com",
-			"icon": "https://raw.githubusercontent.com/dani-garcia/vaultwarden/6edceb5f7acfee8ffe1ae2f07afd76dc588dda60/resources/vaultwarden-icon.svg"
+			"desc": "Stremio add-on for torrents.",
+			"href": "https://addon-manager.simoncaignart.com",
+			"icon": "https://addon-manager.simoncaignart.com/logo.png"
 		}
-
 	]
 }

--- a/apps/maille/compose.yaml
+++ b/apps/maille/compose.yaml
@@ -19,6 +19,55 @@ services:
       timeout: 3s
       retries: 20
 
+  # Daily pg_dump into a local volume, connects over the network (no docker
+  # socket needed). Keeps a short local rotation; offsite copy + alerting is
+  # handled by maille_backup_offsite below.
+  maille_backup_dump:
+    image: prodrigestivill/postgres-backup-local:16
+    container_name: maille_backup_dump
+    profiles: ["maille"]
+    restart: unless-stopped
+    user: "${PUID}:${PGID}"
+    environment:
+      TZ: "${TZ}"
+      POSTGRES_HOST: maille_postgres
+      POSTGRES_DB: maille
+      POSTGRES_USER: maille
+      POSTGRES_PASSWORD: "${MAILLE_DB_PASSWORD?}"
+      SCHEDULE: "@daily"
+      BACKUP_KEEP_DAYS: "7"
+      BACKUP_KEEP_WEEKS: "0"
+      BACKUP_KEEP_MONTHS: "0"
+      HEALTHCHECK_PORT: "8080"
+    volumes:
+      - maille_db_dumps:/backups
+    depends_on:
+      maille_postgres:
+        condition: service_healthy
+
+  # Ships the local dumps to Backblaze B2 (S3-compatible, free tier) and
+  # pings the Uptime Kuma push monitor so a missed/failed backup alerts us.
+  maille_backup_offsite:
+    image: offen/docker-volume-backup:v2
+    container_name: maille_backup_offsite
+    profiles: ["maille"]
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      BACKUP_CRON: "0 4 * * *"
+      BACKUP_FILENAME: "maille-db-%Y-%m-%dT%H-%M-%S.tar.gz"
+      BACKUP_SOURCES: /dumps
+      BACKUP_RETENTION_DAYS: "30"
+      AWS_S3_BUCKET_NAME: "${MAILLE_BACKUP_B2_BUCKET?}"
+      AWS_ENDPOINT: "${MAILLE_BACKUP_B2_ENDPOINT?}"
+      AWS_ACCESS_KEY_ID: "${MAILLE_BACKUP_B2_KEY_ID?}"
+      AWS_SECRET_ACCESS_KEY: "${MAILLE_BACKUP_B2_APP_KEY?}"
+      NOTIFICATION_URLS: "generic+${MAILLE_BACKUP_KUMA_PUSH_URL?}"
+    volumes:
+      - maille_db_dumps:/dumps:ro
+    depends_on:
+      - maille_backup_dump
+
   maille_server:
     image: ghcr.io/simon-caignart/suivi-ca-server:latest
     container_name: maille_server
@@ -62,6 +111,9 @@ services:
       traefik.http.routers.maille-web.tls.certresolver: "letsencrypt"
       traefik.http.routers.maille-web.priority: "1"
       traefik.http.services.maille-web.loadbalancer.server.port: "80"
+
+volumes:
+  maille_db_dumps:
 
 networks:
   my-vps-network:

--- a/apps/maille/compose.yaml
+++ b/apps/maille/compose.yaml
@@ -1,0 +1,68 @@
+services:
+  maille_postgres:
+    image: postgres:16-alpine
+    container_name: maille_postgres
+    profiles: ["maille"]
+    restart: unless-stopped
+    environment:
+      TZ: "${TZ}"
+      POSTGRES_USER: maille
+      POSTGRES_PASSWORD: "${MAILLE_DB_PASSWORD?}"
+      POSTGRES_DB: maille
+    volumes:
+      - "${DOCKER_DATA_DIR}/maille/db:/var/lib/postgresql/data"
+    ports:
+      - "127.0.0.1:${MAILLE_DB_PORT?}:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U maille -d maille"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
+
+  maille_server:
+    image: ghcr.io/simon-caignart/suivi-ca-server:latest
+    container_name: maille_server
+    profiles: ["maille"]
+    restart: unless-stopped
+    user: "${PUID}:${PGID}"
+    env_file: .env
+    environment:
+      TZ: "${TZ}"
+      NODE_ENV: production
+      PORT: "3000"
+      DATABASE_URL: "postgres://maille:${MAILLE_DB_PASSWORD?}@maille_postgres:5432/maille"
+    depends_on:
+      maille_postgres:
+        condition: service_healthy
+    networks:
+      - my-vps-network
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.maille-api.rule: "Host(`${MAILLE_HOSTNAME?}`) && PathPrefix(`/api`)"
+      traefik.http.routers.maille-api.entrypoints: "web,websecure"
+      traefik.http.routers.maille-api.tls.certresolver: "letsencrypt"
+      traefik.http.routers.maille-api.priority: "10"
+      traefik.http.routers.maille-api.middlewares: "maille-api-stripprefix"
+      traefik.http.middlewares.maille-api-stripprefix.stripprefix.prefixes: "/api"
+      traefik.http.services.maille-api.loadbalancer.server.port: "3000"
+
+  maille_client:
+    image: ghcr.io/simon-caignart/suivi-ca-client:latest
+    container_name: maille_client
+    profiles: ["maille"]
+    restart: unless-stopped
+    environment:
+      TZ: "${TZ}"
+    networks:
+      - my-vps-network
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.maille-web.rule: "Host(`${MAILLE_HOSTNAME?}`)"
+      traefik.http.routers.maille-web.entrypoints: "web,websecure"
+      traefik.http.routers.maille-web.tls.certresolver: "letsencrypt"
+      traefik.http.routers.maille-web.priority: "1"
+      traefik.http.services.maille-web.loadbalancer.server.port: "80"
+
+networks:
+  my-vps-network:
+    external: true

--- a/apps/nocodb/compose.yaml
+++ b/apps/nocodb/compose.yaml
@@ -1,0 +1,43 @@
+services:
+  nocodb_postgres:
+    image: postgres:16-alpine
+    container_name: nocodb_postgres
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - ${DOCKER_DATA_DIR}/nocodb/db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-nocodb} -d ${POSTGRES_DB:-nocodb}"]
+      interval: 20s
+      timeout: 5s
+      retries: 5
+    profiles:
+      - nocodb
+      - all
+
+  nocodb:
+    image: nocodb/nocodb:latest
+    container_name: nocodb
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      TZ: ${TZ:-UTC}
+    expose:
+      - 8080
+    volumes:
+      - ${DOCKER_DATA_DIR}/nocodb/app:/usr/app/data
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.nocodb.rule=Host(`${NOCODB_HOSTNAME?}`)"
+      - "traefik.http.routers.nocodb.entrypoints=websecure"
+      - "traefik.http.routers.nocodb.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.nocodb.middlewares=authelia@docker"
+      - "traefik.http.services.nocodb.loadbalancer.server.port=8080"
+    depends_on:
+      nocodb_postgres:
+        condition: service_healthy
+    profiles:
+      - nocodb
+      - all

--- a/apps/zapclone/compose.yaml
+++ b/apps/zapclone/compose.yaml
@@ -1,0 +1,49 @@
+services:
+  zapclone:
+    container_name: 'zapclone'
+    image: 'ghcr.io/simon-caignart/zapclone:sha-c6105dd'
+    restart: 'unless-stopped'
+    user: $PUID:$PGID
+    environment:
+      TZ: ${TZ:-Etc/UTC}
+      NODE_ENV: production
+      DATABASE_URL: postgresql://postgres-zapclone:${ZAPCLONE_DB_PASSWORD?}@zapclone_postgres:5432/zapclone?schema=public
+      SHOPIFY_API_KEY: ${SHOPIFY_API_KEY?}
+      SHOPIFY_API_SECRET: ${SHOPIFY_API_SECRET?}
+      SHOPIFY_APP_URL: ${SHOPIFY_APP_URL?}
+      SCOPES: ${ZAPCLONE_SCOPES?}
+      SHOPIFY_BILLING_TEST: ${SHOPIFY_BILLING_TEST?}
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.zapclone.rule=Host(`${ZAPCLONE_HOSTNAME?}`)"
+      - "traefik.http.routers.zapclone.entryPoints=web,websecure"
+      - "traefik.http.routers.zapclone.tls.certresolver=letsencrypt"
+      - "traefik.http.services.zapclone.loadbalancer.server.port=3000"
+    depends_on:
+      zapclone_postgres:
+        condition: service_healthy
+    profiles:
+      - zapclone
+      - all
+
+  zapclone_postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    container_name: zapclone_postgres
+    volumes:
+      - ${DOCKER_DATA_DIR}/zapclone/db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres-zapclone
+      POSTGRES_PASSWORD: ${ZAPCLONE_DB_PASSWORD?}
+      POSTGRES_DB: zapclone
+    ports:
+      - "127.0.0.1:5432:5432"      
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres-zapclone -d zapclone"]
+      start_period: 1m
+      interval: 20s
+      timeout: 5s
+      retries: 5
+    profiles:
+      - zapclone
+      - all

--- a/compose.yaml
+++ b/compose.yaml
@@ -51,11 +51,13 @@ include:
   - apps/karakeep/compose.yaml
   - apps/kometa/compose.yaml
   - apps/librespeed/compose.yaml
+  - apps/maille/compose.yaml
   - apps/mealie/compose.yaml
   - apps/mediaflow-proxy/compose.yaml
   - apps/mediafusion/compose.yaml
   - apps/minecraft/compose.yaml
   - apps/nitter/compose.yaml
+  - apps/nocodb/compose.yaml
   - apps/notifiarr/compose.yaml
   - apps/ntfy/compose.yaml
   - apps/nzbdav/compose.yaml
@@ -114,10 +116,11 @@ include:
   - apps/wud/compose.yaml
   - apps/xrdb/compose.yaml
   - apps/yamtrack/compose.yaml
+  - apps/zapclone/compose.yaml
   - apps/zilean/compose.yaml
   - apps/zipline/compose.yaml
   # If you would like to use wests scripts, which include blackhole and repair, uncomment the line below.
-  # It is recommended you use decypharr instead, however. 
+  # It is recommended you use decypharr instead, however.
   # - apps/wests-scripts/compose.yaml
   # Uncomment if you are using zurg and comment out decypharr
   # There is also a way to use both together, but it requires 2 rclone instances


### PR DESCRIPTION
## Summary
- Daily pg_dump of the maille Postgres DB, kept locally 7 days
- Offsite copy shipped to Backblaze B2 (S3-compatible, free tier), pruned after 30 days
- Pings an Uptime Kuma push monitor so a missed/failed backup surfaces via existing alerts

## Test plan
- [ ] Fill in `apps/maille/.env` (B2 creds + Kuma push URL) on the VPS
- [ ] `docker compose --profile maille config` resolves cleanly
- [ ] `docker compose --profile maille up -d`
- [ ] Manually trigger a backup and confirm the file lands in the B2 bucket
- [ ] Confirm the Kuma push monitor goes green